### PR TITLE
Feat: Persist and pre-fill Wi-Fi SSID in web UI

### DIFF
--- a/components/app_local_server/CMakeLists.txt
+++ b/components/app_local_server/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(SRCS "app_local_server.c"
                     INCLUDE_DIRS "include"
                     REQUIRES json esp_http_server esp_timer esp_wifi app_update nvs_storage
-                    EMBED_FILES webpage/index.html webpage/app.css webpage/app.js webpage/jquery-3.3.1.min.js webpage/favicon.ico)
+                    EMBED_FILES webpage/index.html webpage/app.css webpage/app.js webpage/jquery-3.3.1.min.js webpage/favicon.ico
+                    PRIV_REQUIRES main nvs_storage)

--- a/components/app_local_server/app_local_server.c
+++ b/components/app_local_server/app_local_server.c
@@ -19,8 +19,10 @@
 #include "esp_http_server.h"
 #include <cJSON.h>
 #include <time.h>
+#include "nvs.h"
 
 #include "app_local_server.h"
+#include "app_station.h"
 
 
 // DEFINES
@@ -105,7 +107,7 @@ static int16_t get_temperature(void);
 static int16_t get_humidity(void);
 bool get_data_rsp_string(char *key, char *buffer, uint16_t len);
 static esp_err_t http_server_wifi_connect_handler(httpd_req_t *req);
-
+static esp_err_t http_server_get_saved_station_ssid_handler(httpd_req_t *req);
 
 static const httpd_uri_t uri_handlers[] = {
     {"/", HTTP_GET, http_server_index_html_handler,NULL},
@@ -120,6 +122,7 @@ static const httpd_uri_t uri_handlers[] = {
     {"/getData", HTTP_POST, http_server_get_data_handler,NULL},
     {"/Sensor", HTTP_GET, http_server_sensor_handler, NULL},
     {"/wifiConnect", HTTP_POST, http_server_wifi_connect_handler, NULL},
+    {"/getSavedStationSSID", HTTP_GET, http_server_get_saved_station_ssid_handler, NULL},
 };
 
 // FUNCTIONS
@@ -706,6 +709,58 @@ static esp_err_t http_server_get_data_handler(httpd_req_t *req)
     return error;
 }
 
+/**
+ * @brief HTTP GET handler for getting the saved station SSID from NVS
+ * 
+ * Respond with a JSON object:
+ * {"station_ssid": "your_saved_ssid"} if found, or
+ * {"station_ssid": ""} if not found or an error occurs
+ * 
+ * @param req HTTP request for which the URI needs to be handled
+ * @return ESP_OK on success, ESP_FAIL on failure
+ */
+static esp_err_t http_server_get_saved_station_ssid_handler(httpd_req_t *req)
+{
+    ESP_LOGI(TAG, "Saved Station SSID Requested");
+    char station_ssid[64] = {0}; // Buffer for SSID
+    char station_password[64] = {0}; // Buffer for password (needed for nvs_load, but not sent)
+    char response_json[100];     // Buffer for JSON response
+
+    esp_err_t err = nvs_storage_load_wifi_creds(station_ssid, sizeof(station_ssid), station_password, sizeof(station_password));
+
+    if (err == ESP_OK)
+    {
+        ESP_LOGI(TAG, "Found saved SSID: %s", station_ssid);
+        snprintf(response_json, sizeof(response_json), "\"station_ssid\":\"%s\"", station_ssid);
+    }
+    else if (err == ESP_ERR_NVS_NOT_FOUND)
+    {
+        ESP_LOGI(TAG, "No saved station SSID found in NVS.");
+        snprintf(response_json, sizeof(response_json), "\"station_ssid\":\"\"");
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Error loading station SSID from NVS: %s", esp_err_to_name(err));
+        snprintf(response_json, sizeof(response_json), "\"station_ssid\":\"\""); // Send empty on other errors too
+        // Optionally, you could send a 500 error for internal NVS issues
+        // httpd_resp_send_500(req);
+        // return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    esp_err_t send_err = httpd_resp_send(req, response_json, strlen(response_json));
+
+    if (send_err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Error %d while sending saved SSID response", send_err);
+    }
+    else
+    {
+        ESP_LOGI(TAG, "Saved SSID response sent successfully");
+    }
+    return send_err; // Return the status of sending the response    
+}
+
 static void get_local_time_string(char *time_str, size_t len)
 {
     time_t now = time(NULL);
@@ -793,12 +848,7 @@ static int16_t get_humidity(void)
 
 static esp_err_t http_server_wifi_connect_handler(httpd_req_t *req)
 {
-    bool isComma = false;
-    int32_t length = 0;
-    uint16_t rsp_len = 0;
-    char response[100];
-    char temp_buff[256] = {0};
-    ESP_LOGI(TAG, "Parameters Request Received");
+   ESP_LOGI(TAG, "Parameters Request Received");
 
     // Read request content
     char buf[256];
@@ -820,27 +870,47 @@ static esp_err_t http_server_wifi_connect_handler(httpd_req_t *req)
     httpd_req_get_hdr_value_str(req, "my-connect-ssid", ssid, sizeof(ssid));
     httpd_req_get_hdr_value_str(req, "my-connect-pswd", pswd, sizeof(pswd));
 
-    nvs_storage_save_wifi_creds(ssid, pswd);
+    if (strlen(ssid) == 0) {
+        ESP_LOGE(TAG, "Received empty SSID. Cannot connect.");
+        // Send an error response
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "SSID cannot be empty");
+        return ESP_FAIL;
+    }
 
-    ESP_LOGI(TAG, "ssid: %s, pswd: %s", ssid, pswd);
+    esp_err_t save_err = nvs_storage_save_wifi_creds(ssid, pswd);
 
-    rsp_len = snprintf(response, sizeof(response), "{\"ssid\":\"%s\",\"pswd\":\"%s\"}", ssid, pswd);
+    if (save_err == ESP_OK) {
+        ESP_LOGI(TAG, "Wi-Fi credentials (SSID: %s) saved to NVS.", ssid);
+        // Now, attempt to connect with these new credentials
+        esp_err_t connect_err = app_station_connect_to_ap(ssid, pswd);
+        if (connect_err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to initiate connection to AP %s.", ssid);
+            // Still respond positively for saving, but log error for connection attempt
+        }
+    } else {
+        ESP_LOGE(TAG, "Failed to save Wi-Fi credentials to NVS.");
+        // Consider sending an error response to the client
+    }
+
+
+    // Respond to client (original response logic)
+    char response_buf[100]; // Renamed from 'response' to avoid conflict if it's a global
+    uint16_t rsp_len = snprintf(response_buf, sizeof(response_buf), "\"ssid\":\"%s\",\"pswd_saved\":\"%s\"", ssid, (save_err == ESP_OK) ? "ok" : "failed");
     
-    // Send response back to client
     httpd_resp_set_type(req, "application/json");
+
+    esp_err_t send_err = httpd_resp_send(req, response_buf, rsp_len);
     
-    esp_err_t error = httpd_resp_send(req, response, rsp_len);
-    
-    if (error != ESP_OK)
+    if (send_err != ESP_OK)
     {
-        ESP_LOGE(TAG, "Error %d while sending params response", error);
+        ESP_LOGE(TAG, "Error %d while sending wifi connect response", send_err);
     }
     else
     {
-        ESP_LOGI(TAG, "Params response sent successfully");
+        ESP_LOGI(TAG, "Wifi connect response sent successfully");
     }
 
-    return ESP_OK;
+    return send_err; // Return status of sending the response
 }
 
 // HTTP Error (404) Handler - Redirects all requests to the root page

--- a/components/app_local_server/webpage/app.js
+++ b/components/app_local_server/webpage/app.js
@@ -11,6 +11,7 @@ var wifiConnectInterval = null;
 $(document).ready(function()
 {
   getSSID();
+  getSavedStationSSID();
   getUpdateStatus();
   startSensorInterval();
   startLocalTimeInterval();
@@ -28,6 +29,28 @@ $(document).ready(function()
     disconnectWiFi();
   });
 });
+
+/**
+ * Gets the saved station SSID from the ESP32 and pre-fills the input field.
+ */
+function getSavedStationSSID()
+{
+  $.getJSON('/getSavedStationSSID', function(data) {
+    // console.log("Saved station SSID data:", data); // For debugging
+    if (data && data.hasOwnProperty("station_ssid")) {
+      $("#connect_ssid").val(data["station_ssid"]); // Populate the SSID input field
+      if (data["station_ssid"] !== "") {
+         console.log("Pre-filled SSID: " + data["station_ssid"]);
+      } else {
+         console.log("No saved station SSID to pre-fill.");
+      }
+    } else {
+      console.error("Error or unexpected response from /getSavedStationSSID");
+    }
+  }).fail(function(jqXHR, textStatus, errorThrown) {
+    console.error("Failed to get saved station SSID: " + textStatus + ", " + errorThrown);
+  });
+}
 
 /**
  * Gets file name and size for display on the web page.

--- a/main/app_station.c
+++ b/main/app_station.c
@@ -15,6 +15,7 @@
 #include "esp_event.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
+#include "nvs_storage.h"
 
 #include "lwip/err.h"
 #include "lwip/sys.h"
@@ -27,6 +28,8 @@
 #define EXAMPLE_ESP_WIFI_SSID CONFIG_ESP_WIFI_SSID
 #define EXAMPLE_ESP_WIFI_PASS CONFIG_ESP_WIFI_PASSWORD
 #define EXAMPLE_ESP_MAXIMUM_RETRY CONFIG_ESP_MAXIMUM_RETRY
+
+#define TAG "wifi station"
 
 #if CONFIG_ESP_WPA3_SAE_PWE_HUNT_AND_PECK
 #define ESP_WIFI_SAE_MODE WPA3_SAE_PWE_HUNT_AND_PECK
@@ -56,7 +59,7 @@
 #define ESP_WIFI_SCAN_AUTH_MODE_THRESHOLD WIFI_AUTH_WAPI_PSK
 #endif
 
-static const char *TAG = "wifi station";
+
 
 static int s_retry_num = 0;
 
@@ -68,24 +71,60 @@ static void event_handler(void *arg, esp_event_base_t event_base,
 {
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START)
     {
-        esp_wifi_connect();
+        // esp_wifi_connect() will be called by wifi_init_sta or app_station_connect_to_ap
+        ESP_LOGI(TAG, "WIFI_EVENT_STA_START: System will attempt to connect.");
     }
     else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED)
     {
+        // wifi_event_sta_disconnected_t* event = (wifi_event_sta_disconnected_t*) event_data;
+        // ESP_LOGI(TAG, "Disconnect reason: %d", event->reason);
         if (s_retry_num < EXAMPLE_ESP_MAXIMUM_RETRY)
         {
-            esp_wifi_connect();
+            esp_wifi_connect(); // Attempt to reconnect with the current config
             s_retry_num++;
-            ESP_LOGI(TAG, "retry to connect to the AP");
+            ESP_LOGI(TAG, "Retrying to connect to the AP (%d/%d)...", s_retry_num, EXAMPLE_ESP_MAXIMUM_RETRY);
         }
-        ESP_LOGI(TAG, "connect to the AP fail");
+        else
+        {
+            ESP_LOGI(TAG, "Failed to connect to the AP after %d retries.", EXAMPLE_ESP_MAXIMUM_RETRY);
+            // Optionally, signal permanent failure here
+        }
+        // http_server_monitor_send_msg(HTTP_MSG_WIFI_CONNECT_FAIL); // Example for future status update
     }
     else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP)
     {
         ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
-        ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
-        s_retry_num = 0;
+        ESP_LOGI(TAG, "Got IP:" IPSTR, IP2STR(&event->ip_info.ip));
+        s_retry_num = 0; // Reset retry count on successful connection
+        // http_server_monitor_send_msg(HTTP_MSG_WIFI_CONNECT_SUCCESS); // Example for future status update
     }
+}
+
+esp_err_t app_station_connect_to_ap(const char *ssid, const char *password)
+{
+    ESP_LOGI(TAG, "Attempting to connect to SSID: %s", ssid);
+
+    s_retry_num = 0; // Reset retry counter for new connection attempt
+
+    wifi_config_t wifi_config = {0}; // Initialize to zero
+    strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
+    strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
+    wifi_config.sta.threshold.authmode = ESP_WIFI_SCAN_AUTH_MODE_THRESHOLD; // Or determine dynamically
+    wifi_config.sta.sae_pwe_h2e = ESP_WIFI_SAE_MODE; // If using WPA3
+    // wifi_config.sta.sae_h2e_identifier = EXAMPLE_H2E_IDENTIFIER; // If using WPA3
+
+    // Disconnect if already connected or attempting
+    ESP_ERROR_CHECK(esp_wifi_disconnect());
+    // Set the new configuration
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    // Attempt to connect
+    esp_err_t err = esp_wifi_connect();
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "esp_wifi_connect() called successfully for %s.", ssid);
+    } else {
+        ESP_LOGE(TAG, "esp_wifi_connect() failed for %s: %s", ssid, esp_err_to_name(err));
+    }
+    return err;
 }
 
 void wifi_init_sta(void)
@@ -101,20 +140,37 @@ void wifi_init_sta(void)
                                                         NULL,
                                                         &instance_got_ip));
 
-    wifi_config_t wifi_config = {
-        .sta = {
-            .ssid = EXAMPLE_ESP_WIFI_SSID,
-            .password = EXAMPLE_ESP_WIFI_PASS,
-            /* Authmode threshold resets to WPA2 as default if password matches WPA2 standards (pasword len => 8).
-             * If you want to connect the device to deprecated WEP/WPA networks, Please set the threshold value
-             * to WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK and set the password with length and format matching to
-             * WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK standards.
-             */
-            .threshold.authmode = ESP_WIFI_SCAN_AUTH_MODE_THRESHOLD,
-            .sae_pwe_h2e = ESP_WIFI_SAE_MODE,
-            .sae_h2e_identifier = EXAMPLE_H2E_IDENTIFIER,
-        },
-    };
+    wifi_config_t wifi_config = {0}; // Initialize to zero
+    char nvs_ssid[32] = {0};
+    char nvs_password[64] = {0};
+
+    esp_err_t err = nvs_storage_load_wifi_creds(nvs_ssid, sizeof(nvs_ssid), nvs_password, sizeof(nvs_password));
+
+    if (err == ESP_OK && strlen(nvs_ssid) > 0)
+    {
+        ESP_LOGI(TAG, "Found credentials in NVS. SSID: %s", nvs_ssid);
+        strncpy((char *)wifi_config.sta.ssid, nvs_ssid, sizeof(wifi_config.sta.ssid) -1);
+        strncpy((char *)wifi_config.sta.password, nvs_password, sizeof(wifi_config.sta.password) -1);
+    }
+    else
+    {
+        if (err == ESP_ERR_NVS_NOT_FOUND) {
+            ESP_LOGI(TAG, "No Wi-Fi credentials found in NVS. Using Kconfig default.");
+        } else {
+            ESP_LOGW(TAG, "Error loading Wi-Fi credentials from NVS (%s). Using Kconfig default.", esp_err_to_name(err));
+        }
+        // Fallback to Kconfig defaults if NVS fails or no creds found
+        strncpy((char *)wifi_config.sta.ssid, EXAMPLE_ESP_WIFI_SSID, sizeof(wifi_config.sta.ssid)-1);
+        strncpy((char *)wifi_config.sta.password, EXAMPLE_ESP_WIFI_PASS, sizeof(wifi_config.sta.password)-1);
+    }
+
+    wifi_config.sta.threshold.authmode = ESP_WIFI_SCAN_AUTH_MODE_THRESHOLD;
+    wifi_config.sta.sae_pwe_h2e = ESP_WIFI_SAE_MODE;
+    // wifi_config.sta.sae_h2e_identifier = EXAMPLE_H2E_IDENTIFIER;
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    ESP_LOGI(TAG, "wifi_init_sta finished. Will attempt to connect to %s.", wifi_config.sta.ssid);
+    // esp_wifi_connect() will be called by WIFI_EVENT_STA_START event if Wi-Fi is started
+    // Or, if Wi-Fi is already started, we might need to call it explicitly here if we want an immediate attempt on boot.
+    // For now, the WIFI_EVENT_STA_START handler in main.c will trigger the first connect.
 }

--- a/main/include/app_station.h
+++ b/main/include/app_station.h
@@ -5,5 +5,6 @@
 #define APP_STATION_H
 
 void wifi_init_sta(void);
+esp_err_t app_station_connect_to_ap(const char *ssid, const char *password);
 
 #endif /* APP_STATION_H */


### PR DESCRIPTION
Improves Wi-Fi setup by remembering and pre-filling the last used SSID, enhancing user experience.

- Implements NVS storage for Wi-Fi credentials in `app_station`.
- Adds a new HTTP GET endpoint `/getSavedStationSSID` to `app_local_server` to retrieve the saved station SSID from NVS.
- Updates the web UI (`webpage/app.js`) to call this endpoint on page load and pre-fill the SSID input field.
- Modifies `app_station` to attempt loading and connecting to saved Wi-Fi credentials on startup if available.
- Updates `idf.port` in VSCode settings and adds `nvs_storage` and `main` as private requirements for `app_local_server`.