### PR TITLE
feat: Add spi_ffs_storage with SPIFFS init and test

### DIFF
--- a/components/spi_ffs_storage/CMakeLists.txt
+++ b/components/spi_ffs_storage/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "spi_ffs_storage.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES spiffs)

--- a/components/spi_ffs_storage/include/spi_ffs_storage.h
+++ b/components/spi_ffs_storage/include/spi_ffs_storage.h
@@ -1,0 +1,18 @@
+#ifndef SPI_FFS_STORAGE_H
+#define SPI_FFS_STORAGE_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/unistd.h>
+#include <sys/stat.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_spiffs.h"
+
+
+
+void spi_ffs_storage_init();
+void spi_ffs_storage_test();
+
+#endif

--- a/components/spi_ffs_storage/spi_ffs_storage.c
+++ b/components/spi_ffs_storage/spi_ffs_storage.c
@@ -1,0 +1,119 @@
+#include "spi_ffs_storage.h"
+
+#define TAG "SPIFFS_STORAGE"
+
+void spi_ffs_storage_init() {
+    // Initialize SPIFFS
+    ESP_LOGI(TAG, "Initializing SPIFFS");
+
+    esp_vfs_spiffs_conf_t conf = {
+      .base_path = "/spiffs",
+      .partition_label = NULL,
+      .max_files = 5,
+      .format_if_mount_failed = true
+    };
+
+    // Use settings defined above to initialize and mount SPIFFS filesystem.
+    // Note: esp_vfs_spiffs_register is an all-in-one convenience function.
+    esp_err_t ret = esp_vfs_spiffs_register(&conf);
+
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Failed to mount or format filesystem");
+        } else if (ret == ESP_ERR_NOT_FOUND) {
+            ESP_LOGE(TAG, "Failed to find SPIFFS partition");
+        } else {
+            ESP_LOGE(TAG, "Failed to initialize SPIFFS (%s)", esp_err_to_name(ret));
+        }
+        return;
+    }
+    
+    ESP_LOGI(TAG, "Performing SPIFFS_check().");
+    
+    ret = esp_spiffs_check(conf.partition_label);
+    
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SPIFFS_check() failed (%s)", esp_err_to_name(ret));
+        return;
+    } else {
+        ESP_LOGI(TAG, "SPIFFS_check() successful");
+    }
+
+    size_t total = 0, used = 0;
+
+    ret = esp_spiffs_info(conf.partition_label, &total, &used);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get SPIFFS partition information (%s). Formatting...", esp_err_to_name(ret));
+        esp_spiffs_format(conf.partition_label);
+        return;
+    } else {
+        ESP_LOGI(TAG, "Partition size: total: %d, used: %d", total, used);
+    }
+
+#
+    // Check consistency of reported partiton size info.
+    if (used > total) {
+        ESP_LOGW(TAG, "Number of used bytes cannot be larger than total. Performing SPIFFS_check().");
+        ret = esp_spiffs_check(conf.partition_label);
+        // Could be also used to mend broken files, to clean unreferenced pages, etc.
+        // More info at https://github.com/pellepl/spiffs/wiki/FAQ#powerlosses-contd-when-should-i-run-spiffs_check
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "SPIFFS_check() failed (%s)", esp_err_to_name(ret));
+            return;
+        } else {
+            ESP_LOGI(TAG, "SPIFFS_check() successful");
+        }
+    }
+
+}
+
+void spi_ffs_storage_test()
+{
+    // Use POSIX and C standard library functions to work with files.
+    // First create a file.
+    ESP_LOGI(TAG, "Opening file");
+    FILE* f = fopen("/spiffs/hello.txt", "w");
+    if (f == NULL) {
+        ESP_LOGE(TAG, "Failed to open file for writing");
+        return;
+    }
+    fprintf(f, "Hello World!\n");
+    fclose(f);
+    ESP_LOGI(TAG, "File written");
+
+    // Check if destination file exists before renaming
+    struct stat st;
+    if (stat("/spiffs/foo.txt", &st) == 0) {
+        // Delete it if it exists
+        unlink("/spiffs/foo.txt");
+    }
+
+    // Rename original file
+    ESP_LOGI(TAG, "Renaming file");
+    if (rename("/spiffs/hello.txt", "/spiffs/foo.txt") != 0) {
+        ESP_LOGE(TAG, "Rename failed");
+        return;
+    }
+
+    // Open renamed file for reading
+    ESP_LOGI(TAG, "Reading file");
+    f = fopen("/spiffs/foo.txt", "r");
+    if (f == NULL) {
+        ESP_LOGE(TAG, "Failed to open file for reading");
+        return;
+    }
+    char line[64];
+    fgets(line, sizeof(line), f);
+    fclose(f);
+    // strip newline
+    char* pos = strchr(line, '\n');
+    if (pos) {
+        *pos = '\0';
+    }
+    ESP_LOGI(TAG, "Read from file: '%s'", line);
+
+    // All done, unmount partition and disable SPIFFS
+    // esp_vfs_spiffs_unregister(conf.partition_label);
+    // ESP_LOGI(TAG, "SPIFFS unmounted"); 
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -4,4 +4,4 @@ idf_component_register(SRCS
                         "time_sync.c"
                         "app_station.c" 
                         INCLUDE_DIRS "include"
-                        REQUIRES app_local_server nvs_storage nvs_flash esp_wifi)
+                        REQUIRES app_local_server spi_ffs_storage nvs_storage nvs_flash esp_wifi)

--- a/main/main.c
+++ b/main/main.c
@@ -24,6 +24,7 @@
 #include "dns_server.h"
 #include "time_sync.h"
 #include "nvs_storage.h"
+#include "spi_ffs_storage.h"
 
 #define EXAMPLE_ESP_WIFI_AP_SSID CONFIG_ESP_WIFI_AP_SSID
 #define EXAMPLE_ESP_WIFI_PASS CONFIG_ESP_WIFI_AP_PASSWORD
@@ -78,6 +79,11 @@ void app_main(void)
     
     
     time_sync_init();
+
+    spi_ffs_storage_init();
+
+    spi_ffs_storage_test();
+    
     
     while (1)
     {


### PR DESCRIPTION
This commit introduces a new component `spi_ffs_storage` which includes functions to initialize the SPI Flash File System (SPIFFS) and run a test performing basic file operations (create, write, rename, read).

The main application is updated to:
- Include `spi_ffs_storage` as a dependency.
- Call the SPIFFS initialization and test functions.

Additionally, VSCode settings were updated to change the IDF port and add a file association for `esp_spiffs.h`.