### PR TITLE
Feat/integrate rgb led

### DIFF
--- a/components/rgb_led/CMakeLists.txt
+++ b/components/rgb_led/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "rgb_led.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES driver)

--- a/components/rgb_led/include/rgb_led.h
+++ b/components/rgb_led/include/rgb_led.h
@@ -1,0 +1,53 @@
+/*
+ * rgb_led.h
+ *
+ *  Created on: Oct 11, 2021
+ *      Author: kjagu
+ */
+
+#ifndef MAIN_RGB_LED_H_
+#define MAIN_RGB_LED_H_
+
+// RGB LED GPIOs
+#define RGB_LED_RED_GPIO		5
+#define RGB_LED_GREEN_GPIO		18
+#define RGB_LED_BLUE_GPIO		19
+
+// RGB LED color mix channels
+#define RGB_LED_CHANNEL_NUM		3
+
+// RGB LED configuration
+typedef struct
+{
+	int channel;
+	int gpio;
+	int mode;
+	int timer_index;
+} ledc_info_t;
+
+/**
+ * Color to indicate WiFi application has started.
+ */
+void rgb_led_wifi_app_started(void);
+
+/**
+ * Color to indicate HTTP server has started.
+ */
+void rgb_led_http_server_started(void);
+
+/**
+ * Color to indicate that the ESP32 is connected to an access point.
+ */
+void rgb_led_wifi_connected(void);
+
+/**
+ * Color to indicate that an access point client has connected.
+ */
+void rgb_led_ap_client_connected(void);
+
+/**
+ * Color to indicate that the access point client has been disconnected.
+ */
+void rgb_led_ap_client_disconnected(void);
+
+#endif /* MAIN_RGB_LED_H_ */

--- a/components/rgb_led/rgb_led.c
+++ b/components/rgb_led/rgb_led.c
@@ -1,0 +1,144 @@
+/*
+ * rgb_led.c
+ *
+ *  Created on: Oct 11, 2021
+ *      Author: kjagu
+ */
+
+#include <stdbool.h>
+
+#include "driver/ledc.h"
+#include "rgb_led.h"
+
+// Color definitions
+#define RGB_COLOR_PURPLE 255, 102, 255
+#define RGB_COLOR_CYAN 0, 255, 255
+#define RGB_COLOR_BLUE 0, 0, 255
+#define RGB_COLOR_YELLOW 255, 255, 0
+#define RGB_COLOR_RED 255, 0, 0
+
+// RGB LED Configuration Array
+ledc_info_t ledc_ch[RGB_LED_CHANNEL_NUM];
+
+// handle for rgb_led_pwm_init
+bool g_pwm_init_handle = false;
+
+/**
+ * Initializes the RGB LED settings per channel, including
+ * the GPIO for each color, mode and timer configuration.
+ */
+static void rgb_led_pwm_init(void)
+{
+	int rgb_ch;
+
+	// Red
+	ledc_ch[0].channel		= LEDC_CHANNEL_0;
+	ledc_ch[0].gpio			= RGB_LED_RED_GPIO;
+	ledc_ch[0].mode			= LEDC_HIGH_SPEED_MODE;
+	ledc_ch[0].timer_index	= LEDC_TIMER_0;
+
+	// Green
+	ledc_ch[1].channel		= LEDC_CHANNEL_1;
+	ledc_ch[1].gpio			= RGB_LED_GREEN_GPIO;
+	ledc_ch[1].mode			= LEDC_HIGH_SPEED_MODE;
+	ledc_ch[1].timer_index	= LEDC_TIMER_0;
+
+	// Blue
+	ledc_ch[2].channel		= LEDC_CHANNEL_2;
+	ledc_ch[2].gpio			= RGB_LED_BLUE_GPIO;
+	ledc_ch[2].mode			= LEDC_HIGH_SPEED_MODE;
+	ledc_ch[2].timer_index	= LEDC_TIMER_0;
+
+	// Configure timer zero
+	ledc_timer_config_t ledc_timer =
+	{
+		.duty_resolution	= LEDC_TIMER_8_BIT,
+		.freq_hz			= 100,
+		.speed_mode			= LEDC_HIGH_SPEED_MODE,
+		.timer_num			= LEDC_TIMER_0
+	};
+	ledc_timer_config(&ledc_timer);
+
+	// Configure channels
+	for (rgb_ch = 0; rgb_ch < RGB_LED_CHANNEL_NUM; rgb_ch++)
+	{
+		ledc_channel_config_t ledc_channel =
+		{
+			.channel	= ledc_ch[rgb_ch].channel,
+			.duty		= 0,
+			.hpoint		= 0,
+			.gpio_num	= ledc_ch[rgb_ch].gpio,
+			.intr_type	= LEDC_INTR_DISABLE,
+			.speed_mode = ledc_ch[rgb_ch].mode,
+			.timer_sel	= ledc_ch[rgb_ch].timer_index,
+		};
+		ledc_channel_config(&ledc_channel);
+	}
+
+	g_pwm_init_handle = true;
+}
+
+/**
+ * Sets the RGB color.
+ */
+static void rgb_led_set_color(uint8_t red, uint8_t green, uint8_t blue)
+{
+	// Value should be 0 - 255 for 8 bit number
+	ledc_set_duty(ledc_ch[0].mode, ledc_ch[0].channel, red);
+	ledc_update_duty(ledc_ch[0].mode, ledc_ch[0].channel);
+
+	ledc_set_duty(ledc_ch[1].mode, ledc_ch[1].channel, green);
+	ledc_update_duty(ledc_ch[1].mode, ledc_ch[1].channel);
+
+	ledc_set_duty(ledc_ch[2].mode, ledc_ch[2].channel, blue);
+	ledc_update_duty(ledc_ch[2].mode, ledc_ch[2].channel);
+}
+
+void rgb_led_wifi_app_started(void)
+{
+	if (g_pwm_init_handle == false)
+	{
+		rgb_led_pwm_init();
+	}
+
+	rgb_led_set_color(RGB_COLOR_PURPLE);
+}
+
+void rgb_led_http_server_started(void)
+{
+	if (g_pwm_init_handle == false)
+	{
+		rgb_led_pwm_init();
+	}
+
+	rgb_led_set_color(RGB_COLOR_CYAN);
+}
+
+
+void rgb_led_wifi_connected(void)
+{
+	if (g_pwm_init_handle == false)
+	{
+		rgb_led_pwm_init();
+	}
+
+	rgb_led_set_color(RGB_COLOR_BLUE);
+}
+
+void rgb_led_ap_client_connected(void)
+{
+    if (g_pwm_init_handle == false)
+    {
+        rgb_led_pwm_init();
+    }
+    rgb_led_set_color(RGB_COLOR_YELLOW); // Yellow
+}
+
+void rgb_led_ap_client_disconnected(void)
+{
+	if (g_pwm_init_handle == false)
+	{
+		rgb_led_pwm_init();
+	}
+	rgb_led_set_color(RGB_COLOR_RED); // Red
+}

--- a/components/rgb_led/rgb_led.c
+++ b/components/rgb_led/rgb_led.c
@@ -53,11 +53,15 @@ static void rgb_led_pwm_init(void)
 	ledc_timer_config_t ledc_timer =
 	{
 		.duty_resolution	= LEDC_TIMER_8_BIT,
-		.freq_hz			= 100,
+		.freq_hz			= 5000,
 		.speed_mode			= LEDC_HIGH_SPEED_MODE,
 		.timer_num			= LEDC_TIMER_0
 	};
-	ledc_timer_config(&ledc_timer);
+	esp_err_t ret = ledc_timer_config(&ledc_timer);
+	if (ret != ESP_OK) {
+		// Handle timer configuration error
+		return;
+	}
 
 	// Configure channels
 	for (rgb_ch = 0; rgb_ch < RGB_LED_CHANNEL_NUM; rgb_ch++)
@@ -72,7 +76,11 @@ static void rgb_led_pwm_init(void)
 			.speed_mode = ledc_ch[rgb_ch].mode,
 			.timer_sel	= ledc_ch[rgb_ch].timer_index,
 		};
-		ledc_channel_config(&ledc_channel);
+		esp_err_t ret = ledc_channel_config(&ledc_channel);
+		if (ret != ESP_OK) {
+			// Handle channel configuration error
+			return;
+		}
 	}
 
 	g_pwm_init_handle = true;
@@ -94,51 +102,44 @@ static void rgb_led_set_color(uint8_t red, uint8_t green, uint8_t blue)
 	ledc_update_duty(ledc_ch[2].mode, ledc_ch[2].channel);
 }
 
-void rgb_led_wifi_app_started(void)
+/**
+ * @brief Ensures PWM is initialized and sets the color.
+ * 
+ * @param red 
+ * @param green 
+ * @param blue 
+ */
+static void rgb_led_ensure_init_and_set_color(uint8_t red, uint8_t green, uint8_t blue)
 {
 	if (g_pwm_init_handle == false)
 	{
 		rgb_led_pwm_init();
 	}
+	rgb_led_set_color(red, green, blue);
+}
 
-	rgb_led_set_color(RGB_COLOR_PURPLE);
+void rgb_led_wifi_app_started(void)
+{
+	rgb_led_ensure_init_and_set_color(RGB_COLOR_PURPLE);
 }
 
 void rgb_led_http_server_started(void)
 {
-	if (g_pwm_init_handle == false)
-	{
-		rgb_led_pwm_init();
-	}
-
-	rgb_led_set_color(RGB_COLOR_CYAN);
+	rgb_led_ensure_init_and_set_color(RGB_COLOR_CYAN);
 }
 
 
 void rgb_led_wifi_connected(void)
 {
-	if (g_pwm_init_handle == false)
-	{
-		rgb_led_pwm_init();
-	}
-
-	rgb_led_set_color(RGB_COLOR_BLUE);
+	rgb_led_ensure_init_and_set_color(RGB_COLOR_BLUE);
 }
 
 void rgb_led_ap_client_connected(void)
 {
-    if (g_pwm_init_handle == false)
-    {
-        rgb_led_pwm_init();
-    }
-    rgb_led_set_color(RGB_COLOR_YELLOW); // Yellow
+    rgb_led_ensure_init_and_set_color(RGB_COLOR_YELLOW); // Yellow
 }
 
 void rgb_led_ap_client_disconnected(void)
 {
-	if (g_pwm_init_handle == false)
-	{
-		rgb_led_pwm_init();
-	}
-	rgb_led_set_color(RGB_COLOR_RED); // Red
+	rgb_led_ensure_init_and_set_color(RGB_COLOR_RED); // Red
 }

--- a/components/rgb_led/test/CMakeLists.txt
+++ b/components/rgb_led/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRC_DIRS "."
+                    INCLUDE_DIRS "."
+                    REQUIRES rgb_led unity)

--- a/components/rgb_led/test/rgb_led_test.c
+++ b/components/rgb_led/test/rgb_led_test.c
@@ -1,0 +1,45 @@
+#include "unity.h"
+#include "rgb_led.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <stdio.h>
+
+TEST_CASE("rgb_led_wifi_app_started_test", "[rgb_led]")
+{
+    printf("Testing WiFi App Started color...\n");
+    rgb_led_wifi_app_started();
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Delay to observe color
+    TEST_PASS();
+}
+
+TEST_CASE("rgb_led_http_server_started_test", "[rgb_led]")
+{
+    printf("Testing HTTP Server Started color...\n");
+    rgb_led_http_server_started();
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Delay to observe color
+    TEST_PASS();
+}
+
+TEST_CASE("rgb_led_wifi_connected_test", "[rgb_led]")
+{
+    printf("Testing WiFi Connected color...\n");
+    rgb_led_wifi_connected();
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Delay to observe color
+    TEST_PASS();
+}
+
+TEST_CASE("rgb_led_ap_client_connected_test", "[rgb_led]")
+{
+    printf("Testing AP Client Connected color...\n");
+    rgb_led_ap_client_connected();
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Delay to observe color
+    TEST_PASS();
+}
+
+TEST_CASE("rgb_led_ap_client_disconnected_test", "[rgb_led]")
+{
+    printf("Testing AP Client Disconnected color...\n");
+    rgb_led_ap_client_disconnected();
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Delay to observe color
+    TEST_PASS();
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c" "dns_server.c"
     INCLUDE_DIRS "include"
-    REQUIRES app_wifi app_time_sync app_local_server nvs_storage rfid_manager spi_ffs_storage esp_netif esp_event unity
+    REQUIRES app_wifi app_time_sync app_local_server nvs_storage rfid_manager spi_ffs_storage esp_netif esp_event unity rgb_led
 )

--- a/main/main.c
+++ b/main/main.c
@@ -145,16 +145,7 @@ static void wifi_event_callback(app_wifi_status_t status, void *user_data)
                 // Number of connected stations logging removed as app_wifi_get_connected_stations was removed.
             }
             break;
-        case APP_WIFI_STATUS_AP_CLIENT_CONNECTED:
-            ESP_LOGI(TAG, "AP client connected");
-            rgb_led_ap_client_connected();
-            break;
-
-        case APP_WIFI_STATUS_AP_CLIENT_DISCONNECTED:
-            ESP_LOGI(TAG, "AP client disconnected");
-            rgb_led_ap_client_disconnected();
-            break;
-            
+           
         case APP_WIFI_STATUS_DISCONNECTED:
             ESP_LOGI(TAG, "WiFi station disconnected");
             break;

--- a/main/main.c
+++ b/main/main.c
@@ -25,6 +25,7 @@
 #include "spi_ffs_storage.h"
 #include "rfid_manager.h" // Added for RFID Management
 #include "custom_partition.h" // Added for custom NVS partition testing
+#include "rgb_led.h"
 
 #define EXAMPLE_ESP_WIFI_AP_SSID CONFIG_ESP_WIFI_AP_SSID
 #define EXAMPLE_ESP_WIFI_PASS CONFIG_ESP_WIFI_AP_PASSWORD
@@ -38,6 +39,7 @@ static void time_sync_callback(app_time_sync_status_t status, time_t current_tim
 
 void app_main(void)
 {
+    rgb_led_wifi_app_started();
     ESP_LOGI(TAG, "Starting Captive Portal Application");
 
     /* Initialize core systems */
@@ -97,6 +99,7 @@ void app_main(void)
     /* Start DNS server */
     ESP_LOGI(TAG, "Starting DNS server");
     ESP_ERROR_CHECK(start_dns_server());
+    rgb_led_http_server_started();
     
     /* Log startup completion */
     // AP IP logging removed as app_wifi_get_ap_ip was removed. 
@@ -137,9 +140,19 @@ static void wifi_event_callback(app_wifi_status_t status, void *user_data)
         case APP_WIFI_STATUS_CONNECTED:
             {
                 ESP_LOGI(TAG, "WiFi station connected successfully");
+                rgb_led_wifi_connected();
                 // STA IP is logged by app_wifi component on IP_EVENT_STA_GOT_IP.
                 // Number of connected stations logging removed as app_wifi_get_connected_stations was removed.
             }
+            break;
+        case APP_WIFI_STATUS_AP_CLIENT_CONNECTED:
+            ESP_LOGI(TAG, "AP client connected");
+            rgb_led_ap_client_connected();
+            break;
+
+        case APP_WIFI_STATUS_AP_CLIENT_DISCONNECTED:
+            ESP_LOGI(TAG, "AP client disconnected");
+            rgb_led_ap_client_disconnected();
             break;
             
         case APP_WIFI_STATUS_DISCONNECTED:


### PR DESCRIPTION
Add the rgb_led component and the unit tests.
Tested the application with the harware integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGB LED support to visually indicate key system states such as WiFi application start, HTTP server start, and WiFi connection.
  * Integrated RGB LED feedback into the main application flow for enhanced status visibility.

* **Tests**
  * Introduced unit tests to verify RGB LED state indication functions for various network and system events.

* **Chores**
  * Updated build configuration to include the new RGB LED component and its tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->