### PR TITLE
feat: Add DHT22 sensor component and integrate with server

### DIFF
--- a/components/app_local_server/CMakeLists.txt
+++ b/components/app_local_server/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "app_local_server.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES json esp_http_server esp_timer esp_wifi app_update nvs_storage
+                    REQUIRES json esp_http_server esp_timer esp_wifi app_update nvs_storage dht22_sensor
                     EMBED_FILES webpage/index.html webpage/app.css webpage/app.js webpage/jquery-3.3.1.min.js webpage/favicon.ico webpage/rfid_management.html webpage/rfid_management.js
                     PRIV_REQUIRES main nvs_storage)

--- a/components/app_local_server/app_local_server.c
+++ b/components/app_local_server/app_local_server.c
@@ -26,6 +26,7 @@
 // #include "app_station.h" // Replaced by app_wifi.h (implicitly included via app_local_server.h or directly if needed)
 #include "app_wifi.h"     // Ensure app_wifi component is included for app_wifi_connect_sta
 #include "rfid_manager.h" // For RFID card management
+#include "dht22_sensor.h"
 
 // DEFINES
 #define URI_HANDLER_MARGIN (1u)
@@ -110,8 +111,8 @@ static esp_err_t http_server_sensor_handler(httpd_req_t *req); // Add prototype 
 static esp_err_t start_webserver(void);                        // Changed return type
 static void get_local_time_string(char *time_str, size_t len);
 static void get_local_time_string_utc(char *time_str, size_t len);
-static int16_t get_temperature(void);
-static int16_t get_humidity(void);
+static float get_temperature(void);
+static float get_humidity(void);
 bool get_data_rsp_string(char *key, char *buffer, uint16_t len);
 static esp_err_t http_server_wifi_connect_handler(httpd_req_t *req);
 static esp_err_t http_server_get_saved_station_ssid_handler(httpd_req_t *req);
@@ -341,8 +342,7 @@ static esp_err_t http_server_sensor_handler(httpd_req_t *req)
     ESP_LOGI(TAG, "Sensor Data Requested");
 
     // Prepare JSON response
-    // Assuming get_temperature() and get_humidity() return int16_t
-    snprintf(sensor_json, sizeof(sensor_json), "{\"temp\":\"%d\",\"humidity\":\"%d\"}", get_temperature(), get_humidity());
+    snprintf(sensor_json, sizeof(sensor_json), "{\"temp\":\"%.1f\",\"humidity\":\"%.1f\"}", get_temperature(), get_humidity());
 
     httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, sensor_json, strlen(sensor_json));
@@ -866,11 +866,11 @@ bool get_data_rsp_string(char *key, char *buffer, uint16_t len)
     }
     else if (strstr(key, "Temp") != NULL)
     {
-        snprintf(buffer, len, "\"Temp\":\"%d\"", get_temperature()); // Placeholder for temperature
+        snprintf(buffer, len, "\"Temp\":\"%.1f\"", get_temperature());
     }
     else if (strstr(key, "Humidity") != NULL)
     {
-        snprintf(buffer, len, "\"Humidity\":\"%d\"", get_humidity()); // Placeholder for humidity
+        snprintf(buffer, len, "\"Humidity\":\"%.1f\"", get_humidity());
     }
     else if (strstr(key, "UTC") != NULL)
     {
@@ -908,16 +908,14 @@ bool get_data_rsp_string(char *key, char *buffer, uint16_t len)
     return true;
 }
 
-static int16_t get_temperature(void)
+static float get_temperature(void)
 {
-    // return random number between 0 & 100
-    return (rand() % 100);
+    return dht22_get_temperature();
 }
 
-static int16_t get_humidity(void)
+static float get_humidity(void)
 {
-    // return random number between 0 & 100
-    return (rand() % 100);
+    return dht22_get_humidity();
 }
 
 static esp_err_t http_server_wifi_connect_handler(httpd_req_t *req)

--- a/components/dht22_sensor/CMakeLists.txt
+++ b/components/dht22_sensor/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "dht22_sensor.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES driver)

--- a/components/dht22_sensor/dht22_sensor.c
+++ b/components/dht22_sensor/dht22_sensor.c
@@ -98,13 +98,15 @@ static void dht22_task(void *pvParameters)
             uint8_t checksum = data[0] + data[1] + data[2] + data[3];
             if (checksum == data[4])
             {
+                portENTER_CRITICAL(&dht22_mux);
                 humidity = (data[0] << 8 | data[1]) / 10.0f;
                 temperature = ((data[2] & 0x7F) << 8 | data[3]) / 10.0f;
                 if (data[2] & 0x80)
                 {
                     temperature *= -1;
                 }
-                ESP_LOGI(TAG, "Humidity: %.1f%%, Temperature: %.1fC", humidity, temperature);
+                portEXIT_CRITICAL(&dht22_mux);
+                // ESP_LOGI(TAG, "Humidity: %.1f%%, Temperature: %.1fC", humidity, temperature);
             }
             else
             {
@@ -122,16 +124,28 @@ static void dht22_task(void *pvParameters)
 esp_err_t dht22_init(void)
 {
     gpio_reset_pin(DHT22_GPIO);
-    xTaskCreate(dht22_task, "dht22_task", 2048, NULL, 5, NULL);
+    BaseType_t task_result = xTaskCreate(dht22_task, "dht22_task", 2048, NULL, 5, NULL);
+    if (task_result != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create dht22_task");
+        return ESP_FAIL;
+    }
     return ESP_OK;
 }
 
 float dht22_get_temperature(void)
 {
-    return temperature;
+    float temp;
+    portENTER_CRITICAL(&dht22_mux);
+    temp = temperature;
+    portEXIT_CRITICAL(&dht22_mux);
+    return temp;
 }
 
 float dht22_get_humidity(void)
 {
-    return humidity;
+    float hum;
+    portENTER_CRITICAL(&dht22_mux);
+    hum = humidity;
+    portEXIT_CRITICAL(&dht22_mux);
+    return hum;
 }

--- a/components/dht22_sensor/dht22_sensor.c
+++ b/components/dht22_sensor/dht22_sensor.c
@@ -1,0 +1,137 @@
+#include "driver/gpio.h"
+#include "dht22_sensor.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "rom/ets_sys.h"
+
+#define DHT22_GPIO 23
+#define DHT22_DATA_BITS 40
+#define DHT22_DATA_BYTES 5
+#define DHT22_TIMER_INTERVAL 2000
+#define DHT22_TIMEOUT 10000
+
+static const char *TAG = "DHT22";
+
+static float temperature = -100.0f;
+static float humidity = -1.0f;
+static portMUX_TYPE dht22_mux = portMUX_INITIALIZER_UNLOCKED;
+
+static int wait_for_level(int level, int timeout_us)
+{
+    int ticks = 0;
+    while (gpio_get_level(DHT22_GPIO) != level)
+    {
+        if (ticks++ > timeout_us)
+        {
+            return -1;
+        }
+        ets_delay_us(1);
+    }
+    return 0;
+}
+
+static int get_data(uint8_t *data)
+{
+    int i, j = 0, bit = 0;
+    uint8_t byte = 0;
+
+    portENTER_CRITICAL(&dht22_mux);
+
+    gpio_set_direction(DHT22_GPIO, GPIO_MODE_OUTPUT);
+    gpio_set_level(DHT22_GPIO, 0);
+    ets_delay_us(1100);
+    gpio_set_level(DHT22_GPIO, 1);
+    ets_delay_us(30);
+    gpio_set_direction(DHT22_GPIO, GPIO_MODE_INPUT);
+
+    if (wait_for_level(0, DHT22_TIMEOUT) != 0)
+    {
+        portEXIT_CRITICAL(&dht22_mux);
+        return -1;
+    }
+    if (wait_for_level(1, DHT22_TIMEOUT) != 0)
+    {
+        portEXIT_CRITICAL(&dht22_mux);
+        return -1;
+    }
+    if (wait_for_level(0, DHT22_TIMEOUT) != 0)
+    {
+        portEXIT_CRITICAL(&dht22_mux);
+        return -1;
+    }
+
+    for (i = 0; i < DHT22_DATA_BITS; i++)
+    {
+        if (wait_for_level(1, DHT22_TIMEOUT) != 0)
+        {
+            portEXIT_CRITICAL(&dht22_mux);
+            return -1;
+        }
+        ets_delay_us(35);
+        bit = gpio_get_level(DHT22_GPIO);
+        byte = (byte << 1) | bit;
+        if ((i + 1) % 8 == 0)
+        {
+            data[j] = byte;
+            j++;
+            byte = 0;
+        }
+        if (wait_for_level(0, DHT22_TIMEOUT) != 0)
+        {
+            portEXIT_CRITICAL(&dht22_mux);
+            return -1;
+        }
+    }
+
+    portEXIT_CRITICAL(&dht22_mux);
+    return 0;
+}
+
+static void dht22_task(void *pvParameters)
+{
+    uint8_t data[DHT22_DATA_BYTES];
+    while (1)
+    {
+        if (get_data(data) == 0)
+        {
+            uint8_t checksum = data[0] + data[1] + data[2] + data[3];
+            if (checksum == data[4])
+            {
+                humidity = (data[0] << 8 | data[1]) / 10.0f;
+                temperature = ((data[2] & 0x7F) << 8 | data[3]) / 10.0f;
+                if (data[2] & 0x80)
+                {
+                    temperature *= -1;
+                }
+                ESP_LOGI(TAG, "Humidity: %.1f%%, Temperature: %.1fC", humidity, temperature);
+            }
+            else
+            {
+                ESP_LOGE(TAG, "Checksum error");
+            }
+        }
+        else
+        {
+            ESP_LOGE(TAG, "Failed to read data from sensor");
+        }
+        vTaskDelay(pdMS_TO_TICKS(DHT22_TIMER_INTERVAL));
+    }
+}
+
+esp_err_t dht22_init(void)
+{
+    gpio_reset_pin(DHT22_GPIO);
+    xTaskCreate(dht22_task, "dht22_task", 2048, NULL, 5, NULL);
+    return ESP_OK;
+}
+
+float dht22_get_temperature(void)
+{
+    return temperature;
+}
+
+float dht22_get_humidity(void)
+{
+    return humidity;
+}

--- a/components/dht22_sensor/include/dht22_sensor.h
+++ b/components/dht22_sensor/include/dht22_sensor.h
@@ -1,0 +1,32 @@
+#ifndef DHT22_H
+#define DHT22_H
+
+#include "esp_err.h"
+
+/**
+ * @brief Initializes the DHT22 sensor.
+ *
+ * This function sets up the GPIO pin for the DHT22 sensor and starts a FreeRTOS task
+ * to periodically read the sensor data.
+ *
+ * @return esp_err_t 
+ *      - ESP_OK on success
+ *      - ESP_FAIL on failure
+ */
+esp_err_t dht22_init(void);
+
+/**
+ * @brief Gets the last read temperature from the DHT22 sensor.
+ *
+ * @return The temperature in degrees Celsius. Returns -100.0 if no data is available.
+ */
+float dht22_get_temperature(void);
+
+/**
+ * @brief Gets the last read humidity from the DHT22 sensor.
+ *
+ * @return The relative humidity in percent. Returns -1.0 if no data is available.
+ */
+float dht22_get_humidity(void);
+
+#endif /* DHT22_H */

--- a/components/dht22_sensor/test/CMakeLists.txt
+++ b/components/dht22_sensor/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRC_DIRS "."
+                    INCLUDE_DIRS "."
+                    REQUIRES dht22_sensor unity)

--- a/components/dht22_sensor/test/dht22_test.c
+++ b/components/dht22_sensor/test/dht22_test.c
@@ -20,13 +20,33 @@ static void setup_sensor(void)
 TEST_CASE("dht22 sensor reads temperature data", "[dht22]")
 {
     setup_sensor();
+
+    // Error handling: simulate or check for sensor read failure (if possible)
     float temp = dht22_get_temperature();
     printf("Temperature: %.1fC\n", temp);
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(-100.0f, temp, "Sensor returned error value for temperature");
 
-    // Basic sanity check
-    TEST_ASSERT_NOT_EQUAL(-100.0f, temp);
-    TEST_ASSERT_TRUE(temp > -40.0f && temp < 80.0f);
+    // Multiple consecutive readings for consistency
+    float temps[5];
+    for (int i = 0; i < 5; ++i) {
+        vTaskDelay(pdMS_TO_TICKS(2000));
+        temps[i] = dht22_get_temperature();
+        printf("Reading %d: %.1fC\n", i+1, temps[i]);
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(-100.0f, temps[i], "Sensor returned error value for temperature on repeated read");
+        TEST_ASSERT_TRUE_MESSAGE(temps[i] > -40.0f && temps[i] < 80.0f, "Temperature out of valid range on repeated read");
+    }
+    // Consistency check: difference between consecutive readings should not be extreme
+    for (int i = 1; i < 5; ++i) {
+        float diff = temps[i] - temps[i-1];
+        TEST_ASSERT_TRUE_MESSAGE(fabsf(diff) < 10.0f, "Unrealistic jump between consecutive temperature readings");
+    }
+
+    // Boundary condition checks (simulate or check for min/max values)
+    // Here, we check that the sensor never returns values outside the valid range
+    TEST_ASSERT_TRUE_MESSAGE(temp >= -40.0f, "Temperature below minimum valid value");
+    TEST_ASSERT_TRUE_MESSAGE(temp <= 80.0f, "Temperature above maximum valid value");
 }
+
 
 TEST_CASE("dht22 sensor reads humidity data", "[dht22]")
 {
@@ -37,4 +57,27 @@ TEST_CASE("dht22 sensor reads humidity data", "[dht22]")
     // Basic sanity check
     TEST_ASSERT_NOT_EQUAL(-1.0f, hum);
     TEST_ASSERT_TRUE(hum >= 0.0f && hum <= 100.0f);
+}
+
+// Error handling test: simulate uninitialized sensor and hardware failure
+TEST_CASE("dht22 sensor error handling scenarios", "[dht22][error]")
+{
+    // Simulate uninitialized sensor by not calling setup_sensor()
+    float temp_uninit = dht22_get_temperature();
+    float hum_uninit = dht22_get_humidity();
+    printf("[Uninitialized] Temperature: %.1fC, Humidity: %.1f%%\n", temp_uninit, hum_uninit);
+    // Should return error values, not crash
+    TEST_ASSERT_EQUAL(-100.0f, temp_uninit);
+    TEST_ASSERT_EQUAL(-1.0f, hum_uninit);
+
+    // Simulate hardware failure by mocking get_data to always fail (if possible)
+    // This is a placeholder: in a real test, use a mock framework or dependency injection
+    // For now, we can at least check that repeated failed reads do not crash or return out-of-range values
+    for (int i = 0; i < 3; ++i) {
+        float temp = dht22_get_temperature();
+        float hum = dht22_get_humidity();
+        TEST_ASSERT_TRUE((temp == -100.0f) || (temp > -40.0f && temp < 80.0f));
+        TEST_ASSERT_TRUE((hum == -1.0f) || (hum >= 0.0f && hum <= 100.0f));
+    }
+    // If mocking is available, insert mock here to force get_data failure and assert error values
 }

--- a/components/dht22_sensor/test/dht22_test.c
+++ b/components/dht22_sensor/test/dht22_test.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include "unity.h"
+#include "dht22_sensor.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+// Helper function to initialize and wait for sensor readings
+static void setup_sensor(void)
+{
+    static bool initialized = false;
+    if (!initialized)
+    {
+        TEST_ASSERT_EQUAL(ESP_OK, dht22_init());
+        // Wait for the sensor to perform a few readings
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        initialized = true;
+    }
+}
+
+TEST_CASE("dht22 sensor reads temperature data", "[dht22]")
+{
+    setup_sensor();
+    float temp = dht22_get_temperature();
+    printf("Temperature: %.1fC\n", temp);
+
+    // Basic sanity check
+    TEST_ASSERT_NOT_EQUAL(-100.0f, temp);
+    TEST_ASSERT_TRUE(temp > -40.0f && temp < 80.0f);
+}
+
+TEST_CASE("dht22 sensor reads humidity data", "[dht22]")
+{
+    setup_sensor();
+    float hum = dht22_get_humidity();
+    printf("Humidity: %.1f%%\n", hum);
+
+    // Basic sanity check
+    TEST_ASSERT_NOT_EQUAL(-1.0f, hum);
+    TEST_ASSERT_TRUE(hum >= 0.0f && hum <= 100.0f);
+}

--- a/main/main.c
+++ b/main/main.c
@@ -26,6 +26,7 @@
 #include "rfid_manager.h" // Added for RFID Management
 #include "custom_partition.h" // Added for custom NVS partition testing
 #include "rgb_led.h"
+#include "dht22_sensor.h"
 
 #define EXAMPLE_ESP_WIFI_AP_SSID CONFIG_ESP_WIFI_AP_SSID
 #define EXAMPLE_ESP_WIFI_PASS CONFIG_ESP_WIFI_AP_PASSWORD
@@ -61,6 +62,9 @@ void app_main(void)
 
     ESP_LOGI(TAG, "Initializing RFID Manager");
     ESP_ERROR_CHECK(rfid_manager_init());
+
+    ESP_LOGI(TAG, "Initializing DHT22 Sensor");
+    ESP_ERROR_CHECK(dht22_init());
     
     /* Test storage functionality */
     // ESP_LOGI(TAG, "Testing SPI FFS storage");


### PR DESCRIPTION
This commit introduces a new component, `dht22_sensor`, for interfacing with a DHT22 temperature and humidity sensor.

The `app_local_server` component is updated to use this new sensor module, replacing the previous placeholder functions that returned random integer values. The server now provides real-time, floating-point sensor data via its API endpoints.

Changes include:
- Added a `dht22_sensor` component with initialization and data reading functions.
- Integrated the sensor readings into the `/sensor` JSON endpoint and WebSocket data responses.
- Updated data types for temperature and humidity from `int16_t` to `float` for better precision.
- Added `dht22_init()` to the main application startup sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the DHT22 temperature and humidity sensor, enabling real-time environmental data readings.
  * Sensor data is now displayed with decimal precision for improved accuracy.
* **Bug Fixes**
  * Improved formatting of temperature and humidity values in responses to use floating-point representation.
* **Tests**
  * Introduced unit tests to verify correct temperature and humidity readings from the DHT22 sensor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->